### PR TITLE
adds margin to the bottom of the elements before footer

### DIFF
--- a/style/branding.css
+++ b/style/branding.css
@@ -353,6 +353,14 @@ fieldset label {
 #footer > span:first-child {
 	margin-left: 10px;
 }
+/* fix of issue simonsoft/rweb-branding#1 */
+/* due to the technical constraints, had to hardcode the previous siblings */
+ul.results,
+.log.xml p:last-of-type,
+.readme.readme-bottom {
+	margin-bottom: 25px;
+}
+
 
 #visualizationOverlay {
 	margin: 10px;


### PR DESCRIPTION
due to the technical constraints of using only css,
and the fact there is no css selector for previous sibling,
the approach taken was to hardcode the css selectors while
overqualifying them. still is not necessarily safe that there are no side-effects
but it doesn't seem to imply any currently.

test it on svn4

closes #1
